### PR TITLE
Fix merging `devDependency` from `package.json`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-JS-Import-Sort  
+# JS-Import-Sort
 
 ![Travis-CI](https://travis-ci.org/Amwam/js-import-sort.svg?branch=master) [![npm version](https://badge.fury.io/js/js-import-sort.svg)](https://badge.fury.io/js/js-import-sort) [![Greenkeeper badge](https://badges.greenkeeper.io/Amwam/js-import-sort.svg)](https://greenkeeper.io/)
 
@@ -7,7 +7,7 @@ JS-Import-Sort
 
 A JS codemod to sort imports
 
-##Intro
+## Intro
 Built on top of [facebook/jscodeshift](https://github.com/facebook/jscodeshift)
 
 This will transform a JS file, sorting and organising its imports (ES2015/ES6).
@@ -54,9 +54,9 @@ Becomes:
    import SomeClass from './MyModule';
 ```
 
-Imports are separated by node, dependencies in `package.json`, other, and relative imports.
- 
-##Running
+Imports are separated by node, dependencies and devDependencies in `package.json`, other, and relative imports.
+
+## Running
 To run, just run:
 
     js-import-sort --path ./*

--- a/__testfixtures__/WithComments.input.js
+++ b/__testfixtures__/WithComments.input.js
@@ -14,9 +14,12 @@ import * as someDefault from 'bbb';
 
 import {a as b} from 'ccc';
 
+import devModule from 'dev-dependency';
 import SomeClass from './MyModule';
 import AnotherClass from '../../Module1';
 
 import * as util from 'util';
 
 import 'yyy';
+
+import module from 'dependency';

--- a/__testfixtures__/WithComments.output.js
+++ b/__testfixtures__/WithComments.output.js
@@ -3,6 +3,9 @@ This is some comment
  */
 import * as util from 'util';
 
+import module from 'dependency';
+import devModule from 'dev-dependency';
+
 import Main, { ZMain } from 'aaaa';
 import * as someDefault from 'bbb';
 import { a as b } from 'ccc';

--- a/__testfixtures__/WithoutComments.input.js
+++ b/__testfixtures__/WithoutComments.input.js
@@ -17,4 +17,4 @@ import AnotherClass from '../../Module1';
 import * as util from 'util';
 
 import 'yyy';
-import 'jscodeshift';
+import 'dependency';

--- a/__testfixtures__/WithoutComments.output.js
+++ b/__testfixtures__/WithoutComments.output.js
@@ -1,6 +1,6 @@
 import * as util from 'util';
 
-import 'jscodeshift';
+import 'dependency';
 
 import Main, { ZMain } from 'aaaa';
 import * as someDefault from 'bbb';

--- a/__tests__/package.json
+++ b/__tests__/package.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "dependency": "^1.0.0"
+  },
+  "devDependencies": {
+    "dev-dependency": "^1.0.0"
+  }
+}

--- a/__tests__/transform.js
+++ b/__tests__/transform.js
@@ -1,4 +1,5 @@
 jest.autoMockOff();
+jest.mock('find-root', () => jest.fn(() => '../__tests__'));
 const defineTest = require('jscodeshift/dist/testUtils').defineTest;
 defineTest(__dirname, 'transform', null, 'WithoutComments');
 defineTest(__dirname, 'transform', null, 'WithComments');

--- a/lib/__tests__/package.json
+++ b/lib/__tests__/package.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "dependency": "^1.0.0"
+  },
+  "devDependencies": {
+    "dev-dependency": "^1.0.0"
+  }
+}

--- a/lib/__tests__/thirdPartyModules.js
+++ b/lib/__tests__/thirdPartyModules.js
@@ -1,0 +1,6 @@
+jest.mock('find-root', () => jest.fn(() => './__tests__'));
+
+const thirdPartyModules = require('../thirdPartyModules').default;
+test('merges dependencies and devDependencies', () => {
+  expect(thirdPartyModules).toEqual(['dependency', 'dev-dependency']);
+});

--- a/lib/thirdPartyModules.js
+++ b/lib/thirdPartyModules.js
@@ -6,8 +6,7 @@ const packageJson = require(findRoot(process.cwd()) + '/package.json');
 const dependencies = {};
 
 if (packageJson) {
-  Object.assign(dependencies, packageJson.dependencies);
-  Object.assign(dependencies, packageJson.devDependencies | {});
+  Object.assign(dependencies, packageJson.dependencies, packageJson.devDependencies);
 }
 
 module.exports = { default: Object.keys(dependencies) };


### PR DESCRIPTION
I noticed that the `devDependency` section of `package.json` was not being merged into the `thirdPartyModules` object correctly.

I added a unit test for the module, as well as changed the test for `transform.js` to use a mocked `package.json` for better test isolation, and updated the test fixtures to exercise the code with that mocked data.  Additionally, I have updated the README to specify that dev dependencies are included alongside the normal dependencies.

Let me know if there's anything else you'd like to see included in this pull request.