### PR TITLE
Fix sorting of `package.json` and node submodules

### DIFF
--- a/__testfixtures__/WithComments.input.js
+++ b/__testfixtures__/WithComments.input.js
@@ -8,6 +8,7 @@ import {ZMain}  from 'aaaa';
 import First from 'zzz';
 import {Third} from 'zzz';
 
+import nodeSubmodule from 'util/submodule';
 import {Second} from 'zzz';
 
 import * as someDefault from 'bbb';
@@ -18,5 +19,8 @@ import SomeClass from './MyModule';
 import AnotherClass from '../../Module1';
 
 import * as util from 'util';
+import submodule from 'dependency/submodule';
 
 import 'yyy';
+
+import module from 'dependency';

--- a/__testfixtures__/WithComments.output.js
+++ b/__testfixtures__/WithComments.output.js
@@ -2,6 +2,10 @@
 This is some comment
  */
 import * as util from 'util';
+import nodeSubmodule from 'util/submodule';
+
+import module from 'dependency';
+import submodule from 'dependency/submodule';
 
 import Main, { ZMain } from 'aaaa';
 import * as someDefault from 'bbb';

--- a/__testfixtures__/WithoutComments.input.js
+++ b/__testfixtures__/WithoutComments.input.js
@@ -17,4 +17,4 @@ import AnotherClass from '../../Module1';
 import * as util from 'util';
 
 import 'yyy';
-import 'jscodeshift';
+import 'dependency';

--- a/__testfixtures__/WithoutComments.output.js
+++ b/__testfixtures__/WithoutComments.output.js
@@ -1,6 +1,6 @@
 import * as util from 'util';
 
-import 'jscodeshift';
+import 'dependency';
 
 import Main, { ZMain } from 'aaaa';
 import * as someDefault from 'bbb';

--- a/__tests__/package.json
+++ b/__tests__/package.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "dependency": "^1.0.0"
+  },
+  "devDependencies": {
+    "dev-dependency": "^1.0.0"
+  }
+}

--- a/__tests__/transform.js
+++ b/__tests__/transform.js
@@ -1,4 +1,5 @@
 jest.autoMockOff();
+jest.mock('find-root', () => jest.fn(() => '../__tests__'));
 const defineTest = require('jscodeshift/dist/testUtils').defineTest;
 defineTest(__dirname, 'transform', null, 'WithoutComments');
 defineTest(__dirname, 'transform', null, 'WithComments');

--- a/transform.js
+++ b/transform.js
@@ -135,9 +135,10 @@ function createOutputImports(newImports, kind) {
   const outputImports = [];
 
   Object.keys(newImports).forEach(key => {
-    if (builtInModules.indexOf(key) > -1) {
+    const baseKey = key.split("/")[0];
+    if (builtInModules.indexOf(baseKey) > -1) {
       nodeModules[key] = newImports[key];
-    } else if (thirdPartyModules.indexOf(key) > -1) {
+    } else if (thirdPartyModules.indexOf(baseKey) > -1) {
       thirdPartyImports[key] = newImports[key];
     } else if (key.startsWith(".")) {
       localImports[key] = newImports[key];


### PR DESCRIPTION
I noticed that submodules of dependencies (and dev dependencies - see #43) were not being sorted correctly.  A specific example would be importing the functional programming extensions of lodash:

```javascript
// package.json
{
  "dependencies": {
    "lodash": "x.x.x"
  }
}

// index.js - unsorted
const fp = require('lodash/fp');
const _ = require('lodash');
const other = require('./other');
const padLeft = require('pad-left');

// index.js - using current sorting logic
const _ = require('lodash');
const padLeft = require('pad-left');

const fp = require('lodash/fp');

const other = require('./other');
```

In this example, the `fp` variant gets sorted down with the "other" modules.

This PR changes the comparison logic for third party modules and node modules to use the identifier before any slashes specifying a submodule.  It also adds an isolated `package.json` mock to be used for the `transform.js` tests (just like in #43), and updates the test fixtures appropriately.

Let me know if there's anything else you'd like to see included in this pull request.